### PR TITLE
Add fuse-device-plugin support for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:stretch-slim
 
-COPY fuse-device-plugin /usr/bin/fuse-device-plugin
+# fuse-device-plugin binary based on architecture
+ARG build_arch
+COPY fuse-device-plugin-${build_arch} /usr/bin/fuse-device-plugin
 
 # replace with your desire device count
 CMD ["fuse-device-plugin", "--mounts_allowed", "5000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# Multi architecture builds
+TARGETS = amd64 arm64
+PLATFORM = linux
+BUILD_TARGETS = $(TARGETS:=.build)
+BUILD_CI_TARGETS = $(TARGETS:=.docker)
+IMAGE_PUSH_TARGETS = $(TARGETS:=.push-image)
+MANIFEST_CREATE_TARGETS = $(PLATFORM:=.create-manifest)
+MANIFEST_PUSH_TARGETS = $(PLATFORM:=.push-manifest)
+BUILD_OPT=""
+IMAGE_TAG=v1.1
+IMAGE_PREFIX=fuse-device-plugin
+IMAGE_REGISTRY=docker.io/soolaugust
+BINARY=fuse-device-plugin
+
+
+.DEFAULT_GOAL := build
+
+# Build binary and docker and then push to docker hub
+.PHONY: all
+all: build docker push-image create-manifest push-manifest
+
+# Build go binaries
+PHONY: build $(BUILD_TARGETS)
+build: $(BUILD_TARGETS)
+%.build:
+	TARGET=$(*) GOOS=linux GOARCH=$(*) CGO_ENABLED=0 GO111MODULE=on go build -o $(BINARY)-${PLATFORM}-$(*)
+
+# Build docker image
+PHONY: docker $(BUILD_CI_TARGETS)
+docker: $(BUILD_CI_TARGETS)
+%.docker:
+	TARGET=$(*) docker build . --platform ${PLATFORM}/$(*) -t $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-$(*)-${IMAGE_TAG} --build-arg build_arch=${PLATFORM}-${*}
+
+#Docker image push
+PHONY: push-image $(IMAGE_PUSH_TARGETS)
+push-image: $(IMAGE_PUSH_TARGETS)
+%.push-image:
+	TARGET=$(*) docker push $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-$(*)-${IMAGE_TAG}
+
+# Create docker manifest for amd64 and arm64
+PHONY: create-manifest $(MANIFEST_CREATE_TARGETS)
+create-manifest: $(MANIFEST_CREATE_TARGETS)
+%.create-manifest:
+	docker manifest create $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):${IMAGE_TAG} -a $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-amd64-${IMAGE_TAG} -a $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-arm64-${IMAGE_TAG}
+	docker manifest annotate --arch amd64 $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):${IMAGE_TAG} $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-amd64-${IMAGE_TAG}
+	docker manifest annotate --arch arm64 $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):${IMAGE_TAG} $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):build-arm64-${IMAGE_TAG}
+
+# docker push manifest and inspect
+PHONY: push-manifest $(MANIFEST_PUSH_TARGETS)
+push-manifest: $(MANIFEST_PUSH_TARGETS)
+%.push-manifest:
+	docker manifest push $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):${IMAGE_TAG}
+	docker manifest inspect $(IMAGE_REGISTRY)/$(IMAGE_PREFIX):${IMAGE_TAG}


### PR DESCRIPTION
Fixes https://github.com/kuberenetes-learning-group/fuse-device-plugin/issues/4

Add fuse-device-plugin support for arm64 arch to help build on `arm64` architecture.

This PR includes following changes::

- Makefile tasks
	- make target to build go binaries for both amd64 and arm64 
	- make target to build docker images for both amd64 and arm64 
	- make target to build docker manifest
	- make target to push docker multi arch images

- Dockerfile
	- copy fuse-device-plugin binary based on architecture

Testing Done:

```
✗ make
TARGET=amd64 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -o fuse-device-plugin-linux-amd64
TARGET=arm64 GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GO111MODULE=on go build -o fuse-device-plugin-linux-arm64
```
```
make all - Create binary and build docker image, manifest and then push to docker hub.

docker manifest inspect docker.io/grayudu/fuse-device-plugin:v1.1
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 740,
         "digest": "sha256:3e727d24c25b21bf647ec83fa2079f7d594a51fe651b8a1b4edf5972753cc90b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 740,
         "digest": "sha256:99cb4b5553960d6070ef06f0aee7a78508f6f777de3dc4f1aaa650d91885a696",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```
https://hub.docker.com/r/grayudu/fuse-device-plugin/tags